### PR TITLE
update csr_iso_modify_mac.sh to supoprt csr16.12+

### DIFF
--- a/box_building/csr_iso_modify_mac.sh
+++ b/box_building/csr_iso_modify_mac.sh
@@ -39,16 +39,16 @@ mkdir mkdir iso
 hdiutil mount $SRC
 
 # Copy SRC ISO Content to Destination
-cp -a /Volumes/CDROM/* iso
+cp -a /Volumes/ISOIMAGE/* iso
 
 # Updating Grub to Boot Serial by default
-sed -i '.bak' '/^default/s/0/1/' iso/boot/grub/menu.lst
+sed -i '.bak' '/^default/s/0/1/' iso/boot/grub/grub.cfg
 
 # Create new ISO
-mkisofs -R -b boot/grub/stage2_eltorito -no-emul-boot -boot-load-size 4 -boot-info-table -o "serial-$(basename $1)" iso
+mkisofs -R -b boot/grub/grub.cfg -no-emul-boot -boot-load-size 4 -boot-info-table -o "serial-$(basename $1)" iso
 
 # Unmount SRC ISO
-hdiutil unmount /Volumes/CDROM
+hdiutil unmount /Volumes/ISOIMAGE
 
 # Move created ISO to original directory
 mv *.iso $PDIR


### PR DESCRIPTION
Receiving following error while running csr_iso_modify_mac.sh for csr1000v-universalk9.17.03.02.iso:

cp: /Volumes/CDROM/*: No such file or directory
sed: iso/boot/grub/grub.cfg: No such file or directory
mkisofs: Uh oh, I cant find the boot image 'boot/grub/stage2_eltorito' inside the target tree.
hdiutil: unmount: "/Volumes/CDROM" failed to unmount due to error 2.
hdiutil: unmount failed - No such file or directory

Issue fixed by changing the mount point and boot file location